### PR TITLE
Use Go's built-in stack trace printer

### DIFF
--- a/util.go
+++ b/util.go
@@ -1,8 +1,7 @@
 package kuberesolver
 
 import (
-	"fmt"
-	"runtime"
+	"runtime/debug"
 	"time"
 
 	"google.golang.org/grpc/grpclog"
@@ -30,14 +29,7 @@ func until(f func(), period time.Duration, stopCh <-chan struct{}) {
 // HandleCrash simply catches a crash and logs an error. Meant to be called via defer.
 func handleCrash() {
 	if r := recover(); r != nil {
-		callers := ""
-		for i := 0; true; i++ {
-			_, file, line, ok := runtime.Caller(i)
-			if !ok {
-				break
-			}
-			callers = callers + fmt.Sprintf("%v:%v\n", file, line)
-		}
+		callers := string(debug.Stack())
 		grpclog.Printf("kuberesolver: recovered from panic: %#v (%v)\n%v", r, r, callers)
 	}
 }


### PR DESCRIPTION
Previous version gave me:

```
blahblah/vendor/github.com/sercand/kuberesolver/util.go:35
/usr/local/go/src/runtime/asm_amd64.s:514
/usr/local/go/src/runtime/panic.go:489
/usr/local/go/src/runtime/panic.go:63
/usr/local/go/src/runtime/signal_unix.go:290
blahblah/vendor/github.com/sercand/kuberesolver/resolver.go:55
blahblah/vendor/github.com/sercand/kuberesolver/resolver.go:38
blahblah/vendor/github.com/sercand/kuberesolver/util.go:20
blahblah/vendor/github.com/sercand/kuberesolver/util.go:21
/usr/local/go/src/runtime/asm_amd64.s:2197
```

This one gives:

```
goroutine 11 [running]:
runtime/debug.Stack(0xc420022b90, 0xbe8040, 0x1290f10)
	/usr/local/go/src/runtime/debug/stack.go:24 +0x79
sercand/kuberesolver.handleCrash()
	blahblah/vendor/github.com/sercand/kuberesolver/util.go:32 +0x57
panic(0xbe8040, 0x1290f10)
	/usr/local/go/src/runtime/panic.go:489 +0x2cf
sercand/kuberesolver.(*kubeResolver).watch(0xc4201e0f20, 0xc4201e0f0d, 0x5, 0xc42006f500, 0xc42006f4a0, 0x0, 0x0)
	blahblah/vendor/github.com/sercand/kuberesolver/resolver.go:55 +0x94
sercand/kuberesolver.(*kubeResolver).Resolve.func1()
	blahblah/vendor/github.com/sercand/kuberesolver/resolver.go:38 +0x52
sercand/kuberesolver.until.func1(0xc4201dee10)
	blahblah/vendor/github.com/sercand/kuberesolver/util.go:19 +0x43
sercand/kuberesolver.until(0xc4201dee10, 0x3b9aca00, 0xc42006f500)
	blahblah/vendor/github.com/sercand/kuberesolver/util.go:20 +0x73
created by sercand/kuberesolver.(*kubeResolver).Resolve
	blahblah/vendor/github.com/sercand/kuberesolver/resolver.go:42 +0x1ac
```

which is a bit nicer