### PR TITLE
Breaking changes on gRPC 1.27.0

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -128,7 +128,7 @@ func parseResolverTarget(target resolver.Target) (targetInfo, error) {
 //
 // gRPC dial calls Build synchronously, and fails if the returned error is
 // not nil.
-func (b *kubeBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOption) (resolver.Resolver, error) {
+func (b *kubeBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
 	if b.k8sClient == nil {
 		if cl, err := NewInClusterK8sClient(); err == nil {
 			b.k8sClient = cl
@@ -189,7 +189,7 @@ type kResolver struct {
 
 // ResolveNow will be called by gRPC to try to resolve the target name again.
 // It's just a hint, resolver can ignore this if it's not necessary.
-func (k *kResolver) ResolveNow(resolver.ResolveNowOption) {
+func (k *kResolver) ResolveNow(resolver.ResolveNowOptions) {
 	select {
 	case k.rn <- struct{}{}:
 	default:

--- a/builder_test.go
+++ b/builder_test.go
@@ -2,6 +2,8 @@ package kuberesolver
 
 import (
 	"fmt"
+	"google.golang.org/grpc/serviceconfig"
+	"log"
 	"strings"
 	"testing"
 
@@ -16,6 +18,21 @@ func newTestBuilder() resolver.Builder {
 type fakeConn struct {
 	cmp   chan struct{}
 	found []string
+}
+
+func (fc *fakeConn) UpdateState(resolver.State) {
+
+}
+
+func (fc *fakeConn) ReportError(e error) {
+	log.Println(e)
+}
+
+func (fc *fakeConn) ParseServiceConfig(serviceConfigJSON string) *serviceconfig.ParseResult {
+	return &serviceconfig.ParseResult{
+		Config: nil,
+		Err:    fmt.Errorf("no implementation for ParseServiceConfig"),
+	}
 }
 
 func (fc *fakeConn) NewAddress(addresses []resolver.Address) {
@@ -37,7 +54,7 @@ func TestBuilder(t *testing.T) {
 	fc := &fakeConn{
 		cmp: make(chan struct{}),
 	}
-	rs, err := bl.Build(resolver.Target{Endpoint: "kube-dns.kube-system:53", Scheme: "kubernetes", Authority: ""}, fc, resolver.BuildOption{})
+	rs, err := bl.Build(resolver.Target{Endpoint: "kube-dns.kube-system:53", Scheme: "kubernetes", Authority: ""}, fc, resolver.BuildOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +63,7 @@ func TestBuilder(t *testing.T) {
 		t.Fatal("could not found endpoints")
 	}
 	fmt.Printf("ResolveNow \n")
-	rs.ResolveNow(resolver.ResolveNowOption{})
+	rs.ResolveNow(resolver.ResolveNowOptions{})
 	<-fc.cmp
 
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/matang28/kuberesolver
+
+go 1.11
+
+require (
+	github.com/prometheus/client_golang v1.4.0
+	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
+	google.golang.org/grpc v1.27.0
+)


### PR DESCRIPTION
When updating to gRPC 1.27 there are breaking changes on gRPC `resolver` package (mainly naming changes).

And I've added a go.mod file, so if you accept this one you'll need to change the module definition to yours.

Currently we are working with this version on PROD and everything seems to work fine.