### PR TITLE
add context to req for cancel watching endpoints when close connection

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -258,7 +258,7 @@ func (k *kResolver) resolve() {
 func (k *kResolver) watch() error {
 	defer k.wg.Done()
 	// watch endpoints lists existing endpoints at start
-	sw, err := watchEndpoints(k.k8sClient, k.target.serviceNamespace, k.target.serviceName)
+	sw, err := watchEndpoints(k.ctx, k.k8sClient, k.target.serviceNamespace, k.target.serviceName)
 	if err != nil {
 		return err
 	}

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -1,6 +1,7 @@
 package kuberesolver
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -175,7 +176,7 @@ func getEndpoints(client K8sClient, namespace, targetName string) (Endpoints, er
 	return result, err
 }
 
-func watchEndpoints(client K8sClient, namespace, targetName string) (watchInterface, error) {
+func watchEndpoints(ctx context.Context, client K8sClient, namespace, targetName string) (watchInterface, error) {
 	u, err := url.Parse(fmt.Sprintf("%s/api/v1/watch/namespaces/%s/endpoints/%s",
 		client.Host(), namespace, targetName))
 	if err != nil {
@@ -185,6 +186,7 @@ func watchEndpoints(client K8sClient, namespace, targetName string) (watchInterf
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err

--- a/stream.go
+++ b/stream.go
@@ -1,6 +1,7 @@
 package kuberesolver
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -78,6 +79,8 @@ func (sw *streamWatcher) receive() {
 			switch err {
 			case io.EOF:
 				// watch closed normally
+			case context.Canceled:
+				// canceled normally
 			case io.ErrUnexpectedEOF:
 				grpclog.Infof("kuberesolver: Unexpected EOF during watch stream event decoding: %v", err)
 			default:


### PR DESCRIPTION
When the resolver is closed, the corresponding 'receive()' goroutine does not exit immediately, but rather tens of minutes later. so in some cases,  the number of coroutines continues to increase. 
The reason is that the http response reader for watching endpoints never ends until k8s apis server complete http response, so we can cancel the http request when resolver is closed.