### PR TITLE
Fully qualified services

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,16 @@ An url can be one of the following, [grpc naming docs](https://github.com/grpc/g
 kubernetes:///service-name:8080
 kubernetes:///service-name:portname
 kubernetes:///service-name.namespace:8080
+kubernetes:///service-name.namespace.svc.cluster_name
+kubernetes:///service-name.namespace.svc.cluster_name:8080
 
 kubernetes://namespace/service-name:8080
 kubernetes://service-name:8080/
 kubernetes://service-name.namespace:8080/
-
+kubernetes://service-name.namespace.svc.cluster_name
+kubernetes://service-name.namespace.svc.cluster_name:8080
 ```
+_* Please note that the cluster_name is not used in resolving the endpoints of a Service. It is only there to support fully qualified service names, e.g._ `test.default.svc.cluster.local`.
 
 ### Using alternative Schema
 

--- a/builder.go
+++ b/builder.go
@@ -73,12 +73,9 @@ type kubeBuilder struct {
 	schema    string
 }
 
-func splitServicePortNamespace(hpn string) (string, string, string) {
-	var (
-		service   = hpn
-		port      string
-		namespace string
-	)
+func splitServicePortNamespace(hpn string) (service, port, namespace string) {
+	service = hpn
+
 	colon := strings.LastIndexByte(service, ':')
 	if colon != -1 {
 		service, port = service[:colon], service[colon+1:]
@@ -93,7 +90,7 @@ func splitServicePortNamespace(hpn string) (string, string, string) {
 		service, namespace = parts[0], parts[1]
 	}
 
-	return service, port, namespace
+	return
 }
 
 func parseResolverTarget(target resolver.Target) (targetInfo, error) {

--- a/builder.go
+++ b/builder.go
@@ -73,20 +73,27 @@ type kubeBuilder struct {
 	schema    string
 }
 
-func splitServicePortNamespace(hpn string) (service, port, namespace string) {
-	service = hpn
-
+func splitServicePortNamespace(hpn string) (string, string, string) {
+	var (
+		service   = hpn
+		port      string
+		namespace string
+	)
 	colon := strings.LastIndexByte(service, ':')
 	if colon != -1 {
 		service, port = service[:colon], service[colon+1:]
 	}
 
-	dot := strings.LastIndexByte(service, '.')
-	if dot != -1 {
-		service, namespace = service[:dot], service[dot+1:]
+	// we want to split into the service name, namespace, and whatever else is left
+	// this will support fully qualified service names, e.g. {service-name}.<namespace>.svc.<cluster-domain-name>.
+	// Note that since we lookup the endpoints by service name and namespace, we don't care about the
+	// cluster-domain-name, only that we can parse out the service name and namespace properly.
+	parts := strings.SplitN(service, ".", 3)
+	if len(parts) >= 2 {
+		service, namespace = parts[0], parts[1]
 	}
 
-	return
+	return service, port, namespace
 }
 
 func parseResolverTarget(target resolver.Target) (targetInfo, error) {

--- a/builder_test.go
+++ b/builder_test.go
@@ -29,7 +29,7 @@ func (fc *fakeConn) ReportError(e error) {
 	log.Println(e)
 }
 
-func (fc *fakeConn) ParseServiceConfig(serviceConfigJSON string) *serviceconfig.ParseResult {
+func (fc *fakeConn) ParseServiceConfig(_ string) *serviceconfig.ParseResult {
 	return &serviceconfig.ParseResult{
 		Config: nil,
 		Err:    fmt.Errorf("no implementation for ParseServiceConfig"),
@@ -116,6 +116,11 @@ func TestParseResolverTarget(t *testing.T) {
 		{parseTarget("//a/b:port"), targetInfo{"b", "a", "port", true, false}, false},
 		{parseTarget("//a/b:port"), targetInfo{"b", "a", "port", true, false}, false},
 		{parseTarget("//a/b:80"), targetInfo{"b", "a", "80", false, false}, false},
+		{parseTarget("a.b.svc.cluster.local"), targetInfo{"a", "b", "", false, true}, false},
+		{parseTarget("/a.b.svc.cluster.local:80"), targetInfo{"a", "b", "80", false, false}, false},
+		{parseTarget("/a.b.svc.cluster.local:port"), targetInfo{"a", "b", "port", true, false}, false},
+		{parseTarget("//a.b.svc.cluster.local"), targetInfo{"a", "b", "", false, true}, false},
+		{parseTarget("//a.b.svc.cluster.local:80"), targetInfo{"a", "b", "80", false, false}, false},
 	} {
 		got, err := parseResolverTarget(test.target)
 		if err == nil && test.err {
@@ -150,6 +155,11 @@ func TestParseTargets(t *testing.T) {
 		{"kubernetes:///a:port", targetInfo{"a", "", "port", true, false}, false},
 		{"kubernetes://x/a:port", targetInfo{"a", "x", "port", true, false}, false},
 		{"kubernetes://a.x:30/", targetInfo{"a", "x", "30", false, false}, false},
+		{"kubernetes://a.b.svc.cluster.local", targetInfo{"a", "b", "", false, true}, false},
+		{"kubernetes://a.b.svc.cluster.local:80", targetInfo{"a", "b", "80", false, false}, false},
+		{"kubernetes:///a.b.svc.cluster.local", targetInfo{"a", "b", "", false, true}, false},
+		{"kubernetes:///a.b.svc.cluster.local:80", targetInfo{"a", "b", "80", false, false}, false},
+		{"kubernetes:///a.b.svc.cluster.local:port", targetInfo{"a", "b", "port", true, false}, false},
 	} {
 		got, err := parseResolverTarget(parseTarget(test.target))
 		if err == nil && test.err {


### PR DESCRIPTION
- added support for fully qualified services names, e.g. `myservice.namespace.svc.cluster.local`.