### PR TITLE
Fix excessive client connection creation

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -167,7 +167,7 @@ func (b *kubeBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts
 		if err != nil && err != io.EOF {
 			grpclog.Errorf("kuberesolver: watching ended with error='%v', will reconnect again", err)
 		}
-	}, time.Second, ctx.Done())
+	}, time.Second, time.Second*30, ctx.Done())
 	return r, nil
 }
 

--- a/builder.go
+++ b/builder.go
@@ -246,7 +246,11 @@ func (k *kResolver) handle(e Endpoints) {
 	result, _ := k.makeAddresses(e)
 	//	k.cc.NewServiceConfig(sc)
 	if len(result) > 0 {
-		k.cc.NewAddress(result)
+		//k.cc.NewAddress(result)
+		err := k.cc.UpdateState(resolver.State{Addresses: result})
+		if err != nil {
+			grpclog.Errorf("kuberesolver: update state failed: %v", err)
+		}
 	}
 
 	k.endpoints.Set(float64(len(e.Subsets)))
@@ -278,7 +282,7 @@ func (k *kResolver) watch() error {
 		case <-k.t.C:
 			k.resolve()
 		case <-k.rn:
-			k.resolve()
+			//k.resolve()
 		case up, hasMore := <-sw.ResultChan():
 			if hasMore {
 				k.handle(up.Object)

--- a/builder.go
+++ b/builder.go
@@ -246,11 +246,7 @@ func (k *kResolver) handle(e Endpoints) {
 	result, _ := k.makeAddresses(e)
 	//	k.cc.NewServiceConfig(sc)
 	if len(result) > 0 {
-		//k.cc.NewAddress(result)
-		err := k.cc.UpdateState(resolver.State{Addresses: result})
-		if err != nil {
-			grpclog.Errorf("kuberesolver: update state failed: %v", err)
-		}
+		k.cc.NewAddress(result)
 	}
 
 	k.endpoints.Set(float64(len(e.Subsets)))

--- a/builder_test.go
+++ b/builder_test.go
@@ -55,7 +55,7 @@ func TestBuilder(t *testing.T) {
 	fc := &fakeConn{
 		cmp: make(chan struct{}),
 	}
-	rs, err := bl.Build(parseTarget("kubernetes://kube-dns.kube-system:53"), fc, resolver.BuildOptions{})
+	_, err = bl.Build(parseTarget("kubernetes://kube-dns.kube-system:53"), fc, resolver.BuildOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,9 +63,9 @@ func TestBuilder(t *testing.T) {
 	if len(fc.found) == 0 {
 		t.Fatal("could not found endpoints")
 	}
-	fmt.Printf("ResolveNow \n")
-	rs.ResolveNow(resolver.ResolveNowOptions{})
-	<-fc.cmp
+// 	fmt.Printf("ResolveNow \n")
+// 	rs.ResolveNow(resolver.ResolveNowOptions{})
+// 	<-fc.cmp
 
 }
 

--- a/util.go
+++ b/util.go
@@ -7,12 +7,13 @@ import (
 	"google.golang.org/grpc/grpclog"
 )
 
-func until(f func(), period time.Duration, stopCh <-chan struct{}) {
+func until(f func(), initialPeriod, maxPeriod time.Duration, stopCh <-chan struct{}) {
 	select {
 	case <-stopCh:
 		return
 	default:
 	}
+	period := initialPeriod
 	for {
 		func() {
 			defer handleCrash()
@@ -22,6 +23,11 @@ func until(f func(), period time.Duration, stopCh <-chan struct{}) {
 		case <-stopCh:
 			return
 		case <-time.After(period):
+			if period*2 <= maxPeriod {
+				period *= 2
+			} else {
+				period = initialPeriod
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR description discusses an issue where each RPC request calls ResolveNow. Due to incorrect handling of this event, a new connection is created for every request. As concurrency increases, so does the number of required connections, leading to timeouts on both the client and server sides when establishing connections.