### PR TITLE
fix: remove usage of deprecated Type attribute of resolver.Address

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -232,7 +232,6 @@ func (k *kResolver) makeAddresses(e Endpoints) ([]resolver.Address, string) {
 
 		for _, address := range subset.Addresses {
 			newAddrs = append(newAddrs, resolver.Address{
-				Type:       resolver.Backend,
 				Addr:       net.JoinHostPort(address.IP, port),
 				ServerName: fmt.Sprintf("%s.%s", k.target.serviceName, k.target.serviceNamespace),
 				Metadata:   nil,

--- a/builder_test.go
+++ b/builder_test.go
@@ -41,7 +41,6 @@ func (fc *fakeConn) NewAddress(addresses []resolver.Address) {
 		fc.found = append(fc.found, a.Addr)
 		fmt.Printf("%d, address: %s\n", i, a.Addr)
 		fmt.Printf("%d, servername: %s\n", i, a.ServerName)
-		fmt.Printf("%d, type: %+v\n", i, a.Type)
 	}
 	fc.cmp <- struct{}{}
 }
@@ -63,9 +62,9 @@ func TestBuilder(t *testing.T) {
 	if len(fc.found) == 0 {
 		t.Fatal("could not found endpoints")
 	}
-// 	fmt.Printf("ResolveNow \n")
-// 	rs.ResolveNow(resolver.ResolveNowOptions{})
-// 	<-fc.cmp
+	// 	fmt.Printf("ResolveNow \n")
+	// 	rs.ResolveNow(resolver.ResolveNowOptions{})
+	// 	<-fc.cmp
 
 }
 


### PR DESCRIPTION
The type attribute has been removed in more recent versions of gRPC. The usage here is not required and the may be removed.

See: https://github.com/grpc/grpc-go/pull/6451
As mentioned in: https://github.com/sercand/kuberesolver/issues/30#issuecomment-1711559798