### PR TITLE
Get rid of deprecated ClientConn.NewAddress

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -242,14 +242,15 @@ func (k *kResolver) makeAddresses(e Endpoints) ([]resolver.Address, string) {
 }
 
 func (k *kResolver) handle(e Endpoints) {
-	result, _ := k.makeAddresses(e)
-	//	k.cc.NewServiceConfig(sc)
-	if len(result) > 0 {
-		k.cc.NewAddress(result)
+	addrs, _ := k.makeAddresses(e)
+	if len(addrs) > 0 {
+		k.cc.UpdateState(resolver.State{
+			Addresses: addrs,
+		})
 	}
 
 	k.endpoints.Set(float64(len(e.Subsets)))
-	k.addresses.Set(float64(len(result)))
+	k.addresses.Set(float64(len(addrs)))
 }
 
 func (k *kResolver) resolve() {

--- a/builder_test.go
+++ b/builder_test.go
@@ -21,7 +21,13 @@ type fakeConn struct {
 	found []string
 }
 
-func (fc *fakeConn) UpdateState(resolver.State) error {
+func (fc *fakeConn) UpdateState(state resolver.State) error {
+	for i, a := range state.Addresses {
+		fc.found = append(fc.found, a.Addr)
+		fmt.Printf("%d, address: %s\n", i, a.Addr)
+		fmt.Printf("%d, servername: %s\n", i, a.ServerName)
+	}
+	fc.cmp <- struct{}{}
 	return nil
 }
 
@@ -37,12 +43,7 @@ func (fc *fakeConn) ParseServiceConfig(_ string) *serviceconfig.ParseResult {
 }
 
 func (fc *fakeConn) NewAddress(addresses []resolver.Address) {
-	for i, a := range addresses {
-		fc.found = append(fc.found, a.Addr)
-		fmt.Printf("%d, address: %s\n", i, a.Addr)
-		fmt.Printf("%d, servername: %s\n", i, a.ServerName)
-	}
-	fc.cmp <- struct{}{}
+	fmt.Printf("addresses: %s\n", addresses)
 }
 
 func (*fakeConn) NewServiceConfig(serviceConfig string) {


### PR DESCRIPTION
This PR removes the usage of deprecated `resolver.ClientConn.NewAddress` as [recommended by the docs][1].

Closes #30.

[1]: https://pkg.go.dev/google.golang.org/grpc@v1.56.3/resolver#ClientConn