### PR TITLE
Update to use Endpoint Slices instead of Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Since it provides and updates all available service endpoints, together with a c
 
 ### RBAC
 
-You need give `GET` and `WATCH` access to the `endpoints` if you are using RBAC in your cluster.
+You need give `GET` and `WATCH` access to the `endpointslices` if you are using RBAC in your cluster.
 
 
 ### Using With TLS

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -152,31 +152,31 @@ func NewInsecureK8sClient(apiURL string) K8sClient {
 	}
 }
 
-func getEndpoints(client K8sClient, namespace, targetName string) (Endpoints, error) {
-	u, err := url.Parse(fmt.Sprintf("%s/api/v1/namespaces/%s/endpoints/%s",
+func getEndpointSliceList(client K8sClient, namespace, targetName string) (EndpointSliceList, error) {
+	u, err := url.Parse(fmt.Sprintf("%s/apis/discovery.k8s.io/v1/namespaces/%s/endpointslices?labelSelector=kubernetes.io/service-name=%s",
 		client.Host(), namespace, targetName))
 	if err != nil {
-		return Endpoints{}, err
+		return EndpointSliceList{}, err
 	}
 	req, err := client.GetRequest(u.String())
 	if err != nil {
-		return Endpoints{}, err
+		return EndpointSliceList{}, err
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return Endpoints{}, err
+		return EndpointSliceList{}, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return Endpoints{}, fmt.Errorf("invalid response code %d for service %s in namespace %s", resp.StatusCode, targetName, namespace)
+		return EndpointSliceList{}, fmt.Errorf("invalid response code %d for service %s in namespace %s", resp.StatusCode, targetName, namespace)
 	}
-	result := Endpoints{}
+	result := EndpointSliceList{}
 	err = json.NewDecoder(resp.Body).Decode(&result)
 	return result, err
 }
 
-func watchEndpoints(ctx context.Context, client K8sClient, namespace, targetName string) (watchInterface, error) {
-	u, err := url.Parse(fmt.Sprintf("%s/api/v1/watch/namespaces/%s/endpoints/%s",
+func watchEndpointSlice(ctx context.Context, client K8sClient, namespace, targetName string) (watchInterface, error) {
+	u, err := url.Parse(fmt.Sprintf("%s/apis/discovery.k8s.io/v1/watch/namespaces/%s/endpointslices?labelSelector=kubernetes.io/service-name=%s",
 		client.Host(), namespace, targetName))
 	if err != nil {
 		return nil, err

--- a/models.go
+++ b/models.go
@@ -11,15 +11,28 @@ const (
 
 // Event represents a single event to a watched resource.
 type Event struct {
-	Type   EventType `json:"type"`
-	Object Endpoints `json:"object"`
+	Type   EventType     `json:"type"`
+	Object EndpointSlice `json:"object"`
 }
 
-type Endpoints struct {
-	Kind       string   `json:"kind"`
-	ApiVersion string   `json:"apiVersion"`
-	Metadata   Metadata `json:"metadata"`
-	Subsets    []Subset `json:"subsets"`
+type EndpointSliceList struct {
+	Items []EndpointSlice
+}
+
+type EndpointSlice struct {
+	Endpoints []Endpoint
+	Ports     []EndpointPort
+}
+
+type Endpoint struct {
+	Addresses  []string
+	Conditions EndpointConditions
+}
+
+type EndpointConditions struct {
+	Ready       *bool `json:"ready"`
+	Serving     *bool `json:"serving"`
+	Terminating *bool `json:"terminating"`
 }
 
 type Metadata struct {
@@ -28,23 +41,7 @@ type Metadata struct {
 	ResourceVersion string            `json:"resourceVersion"`
 	Labels          map[string]string `json:"labels"`
 }
-
-type Subset struct {
-	Addresses []Address `json:"addresses"`
-	Ports     []Port    `json:"ports"`
-}
-
-type Address struct {
-	IP        string           `json:"ip"`
-	TargetRef *ObjectReference `json:"targetRef,omitempty"`
-}
-
-type ObjectReference struct {
-	Kind      string `json:"kind"`
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
-}
-type Port struct {
+type EndpointPort struct {
 	Name string `json:"name"`
 	Port int    `json:"port"`
 }


### PR DESCRIPTION
Fixes https://github.com/sercand/kuberesolver/issues/54

This moves the usage of Endpoints to EndpointSlices which is the "new" API for fetching IPs/ports of pods for services.

We've been using Endpoint Slices for quite a while (including the `Ready` condition check) but I was looking to replace our implementation using the K8s SDK in favor of this to reduce our binary sizes. However, rather than updating all our RBAC and going back to using Endpoints I figured I'd update this library to use EndpointSlices.

I've only been testing this locally so far but appears to be working perfectly fine! I'll likely be rolling this out to our production this week. Happy to address any feedback!

Edit: one consideration is probably making this a new v6 version since it's a breaking change for those using RBAC.