### PR TITLE
Enhance tests and CI configuration for builder with linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: 2.11.3
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test -v -race -count=1 -timeout 120s ./...
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           go-version-file: go.mod
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           version: v2.11.3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,3 @@ jobs:
 
       - name: Run tests
         run: go test -v -race -count=1 -timeout 120s ./...
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6.3.0
         with:
           go-version-file: go.mod
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.11.3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: 2.11.3
+          version: v2.11.3
 
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6.3.0
         with:
           go-version-file: go.mod
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,37 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - contextcheck
+    - copyloopvar
+    - decorder
+    - exhaustive
+    - exptostd
+    - fatcontext
+    - gocheckcompilerdirectives
+    - goconst
+    - gocyclo
+    - importas
+    - predeclared
+    - reassign
+    - recvcheck
+    - tagalign
+    - thelper
+    - tparallel
+    - unconvert
+    - unparam
+    - whitespace
+    - wsl_v5
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # kuberesolver
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/sercand/kuberesolver/v6.svg)](https://pkg.go.dev/github.com/sercand/kuberesolver)
+[![Go Report Card](https://goreportcard.com/badge/github.com/sercand/kuberesolver/v6)](https://goreportcard.com/report/github.com/sercand/kuberesolver/v6)
+[![GitHub release](https://img.shields.io/github/v/release/sercand/kuberesolver)](https://github.com/sercand/kuberesolver/releases)
+
 A Grpc name resolver by using kubernetes API.
 It comes with a small ~250 LOC kubernetes client to find service endpoints. Therefore it won't bloat your binaries.
 

--- a/builder.go
+++ b/builder.go
@@ -124,6 +124,7 @@ func parseResolverTarget(target resolver.Target) (targetInfo, error) {
 	}
 
 	resolveByPortName := false
+
 	useFirstPort := false
 	if port == "" {
 		useFirstPort = true
@@ -153,13 +154,16 @@ func (b *kubeBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts
 			return nil, err
 		}
 	}
+
 	ti, err := parseResolverTarget(target)
 	if err != nil {
 		return nil, err
 	}
+
 	if ti.serviceNamespace == "" {
 		ti.serviceNamespace = getCurrentNamespaceOrDefault()
 	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	r := &kResolver{
 		target:    ti,
@@ -175,12 +179,14 @@ func (b *kubeBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts
 		lastUpdateUnix: clientLastUpdate.WithLabelValues(ti.String()),
 	}
 	r.wg.Add(1)
+
 	go until(func() {
 		err := r.watch()
 		if err != nil && err != io.EOF {
 			grpclog.Errorf("kuberesolver: watching ended with error='%v', will reconnect again", err)
 		}
 	}, time.Second, time.Second*30, ctx.Done())
+
 	return r, nil
 }
 
@@ -236,6 +242,7 @@ func (k *kResolver) makeAddresses(e EndpointSlice) ([]resolver.Address, string) 
 	}
 
 	var newAddrs []resolver.Address
+
 	for _, endpoint := range e.Endpoints {
 		if endpoint.Conditions.Ready == nil || !*endpoint.Conditions.Ready {
 			continue
@@ -256,7 +263,7 @@ func (k *kResolver) makeAddresses(e EndpointSlice) ([]resolver.Address, string) 
 func (k *kResolver) handle(e EndpointSlice) {
 	addrs, _ := k.makeAddresses(e)
 	if len(addrs) > 0 {
-		k.cc.UpdateState(resolver.State{
+		_ = k.cc.UpdateState(resolver.State{
 			Addresses: addrs,
 		})
 		k.lastUpdateUnix.Set(float64(time.Now().Unix()))
@@ -286,6 +293,7 @@ func (k *kResolver) watch() error {
 	if err != nil {
 		return err
 	}
+
 	for {
 		select {
 		case <-k.ctx.Done():

--- a/builder_test.go
+++ b/builder_test.go
@@ -1,9 +1,14 @@
 package kuberesolver
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,9 +18,79 @@ import (
 	"google.golang.org/grpc/serviceconfig"
 )
 
-func newTestBuilder() resolver.Builder {
-	cl := NewInsecureK8sClient("http://127.0.0.1:8001")
-	return NewBuilder(cl, kubernetesSchema)
+// isKubeProxyAvailable checks whether a Kubernetes API proxy is reachable
+// at 127.0.0.1:8001.
+func isKubeProxyAvailable() bool {
+	conn, err := net.DialTimeout("tcp", "127.0.0.1:8001", 2*time.Second)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// newMockKubeServer starts a httptest.Server that returns fake EndpointSlice
+// responses for both the watch and list API paths.
+func newMockKubeServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	ready := true
+	fakeSlice := EndpointSlice{
+		Endpoints: []Endpoint{
+			{
+				Addresses: []string{"10.0.0.1", "10.0.0.2"},
+				Conditions: EndpointConditions{
+					Ready: &ready,
+				},
+			},
+		},
+		Ports: []EndpointPort{
+			{Name: "dns", Port: 53},
+		},
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/watch/") {
+			// Watch endpoint: stream a single ADDED event, then hold the
+			// connection open until the client disconnects.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			event := Event{
+				Type:   Added,
+				Object: fakeSlice,
+			}
+			if err := json.NewEncoder(w).Encode(event); err != nil {
+				t.Logf("mock server: failed to encode watch event: %v", err)
+				return
+			}
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			// Block until the client closes the connection.
+			<-r.Context().Done()
+		} else {
+			// List endpoint
+			w.Header().Set("Content-Type", "application/json")
+			list := EndpointSliceList{
+				Items: []EndpointSlice{fakeSlice},
+			}
+			_ = json.NewEncoder(w).Encode(list)
+		}
+	}))
+}
+
+// getTestAPIURL returns the base URL to use for integration tests together
+// with a cleanup function. It prefers a live kubectl proxy when available and
+// falls back to a local mock server otherwise.
+func getTestAPIURL(t *testing.T) (apiURL string, cleanup func()) {
+	t.Helper()
+	if isKubeProxyAvailable() {
+		t.Log("Using live Kubernetes API proxy at http://127.0.0.1:8001")
+		return "http://127.0.0.1:8001", func() {}
+	}
+	t.Log("Kubernetes API proxy not available, using mock server")
+	srv := newMockKubeServer(t)
+	return srv.URL, srv.Close
 }
 
 type fakeConn struct {
@@ -53,25 +128,11 @@ func (*fakeConn) NewServiceConfig(serviceConfig string) {
 }
 
 func TestBuilder(t *testing.T) {
-	bl := newTestBuilder()
-	fc := &fakeConn{
-		cmp: make(chan struct{}),
-	}
-	_, err := bl.Build(parseTarget("kubernetes://kube-dns.kube-system:53"), fc, resolver.BuildOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	<-fc.cmp
-	if len(fc.found) == 0 {
-		t.Fatal("could not found endpoints")
-	}
-	// 	fmt.Printf("ResolveNow \n")
-	// 	rs.ResolveNow(resolver.ResolveNowOptions{})
-	// 	<-fc.cmp
-}
+	apiURL, cleanup := getTestAPIURL(t)
+	defer cleanup()
 
-func TestResolveLag(t *testing.T) {
-	bl := newTestBuilder()
+	cl := NewInsecureK8sClient(apiURL)
+	bl := NewBuilder(cl, kubernetesSchema)
 	fc := &fakeConn{
 		cmp: make(chan struct{}),
 	}
@@ -79,6 +140,29 @@ func TestResolveLag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer rs.Close()
+
+	<-fc.cmp
+	if len(fc.found) == 0 {
+		t.Fatal("could not found endpoints")
+	}
+}
+
+func TestResolveLag(t *testing.T) {
+	apiURL, cleanup := getTestAPIURL(t)
+	defer cleanup()
+
+	cl := NewInsecureK8sClient(apiURL)
+	bl := NewBuilder(cl, kubernetesSchema)
+	fc := &fakeConn{
+		cmp: make(chan struct{}),
+	}
+	rs, err := bl.Build(parseTarget("kubernetes://kube-dns.kube-system:53"), fc, resolver.BuildOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rs.Close()
+
 	<-fc.cmp
 	if len(fc.found) == 0 {
 		t.Fatal("could not found endpoints")

--- a/builder_test.go
+++ b/builder_test.go
@@ -25,7 +25,9 @@ func isKubeProxyAvailable() bool {
 	if err != nil {
 		return false
 	}
+
 	_ = conn.Close()
+
 	return true
 }
 
@@ -33,6 +35,7 @@ func isKubeProxyAvailable() bool {
 // responses for both the watch and list API paths.
 func newMockKubeServer(t *testing.T) *httptest.Server {
 	t.Helper()
+
 	ready := true
 	fakeSlice := EndpointSlice{
 		Endpoints: []Endpoint{
@@ -63,6 +66,7 @@ func newMockKubeServer(t *testing.T) *httptest.Server {
 				t.Logf("mock server: failed to encode watch event: %v", err)
 				return
 			}
+
 			if f, ok := w.(http.Flusher); ok {
 				f.Flush()
 			}
@@ -71,6 +75,7 @@ func newMockKubeServer(t *testing.T) *httptest.Server {
 		} else {
 			// List endpoint
 			w.Header().Set("Content-Type", "application/json")
+
 			list := EndpointSliceList{
 				Items: []EndpointSlice{fakeSlice},
 			}
@@ -84,12 +89,15 @@ func newMockKubeServer(t *testing.T) *httptest.Server {
 // falls back to a local mock server otherwise.
 func getTestAPIURL(t *testing.T) (apiURL string, cleanup func()) {
 	t.Helper()
+
 	if isKubeProxyAvailable() {
 		t.Log("Using live Kubernetes API proxy at http://127.0.0.1:8001")
 		return "http://127.0.0.1:8001", func() {}
 	}
+
 	t.Log("Kubernetes API proxy not available, using mock server")
 	srv := newMockKubeServer(t)
+
 	return srv.URL, srv.Close
 }
 
@@ -104,7 +112,9 @@ func (fc *fakeConn) UpdateState(state resolver.State) error {
 		fmt.Printf("%d, address: %s\n", i, a.Addr)
 		fmt.Printf("%d, servername: %s\n", i, a.ServerName)
 	}
+
 	fc.cmp <- struct{}{}
+
 	return nil
 }
 
@@ -136,6 +146,7 @@ func TestBuilder(t *testing.T) {
 	fc := &fakeConn{
 		cmp: make(chan struct{}),
 	}
+
 	rs, err := bl.Build(parseTarget("kubernetes://kube-dns.kube-system:53"), fc, resolver.BuildOptions{})
 	if err != nil {
 		t.Fatal(err)
@@ -143,6 +154,7 @@ func TestBuilder(t *testing.T) {
 	defer rs.Close()
 
 	<-fc.cmp
+
 	if len(fc.found) == 0 {
 		t.Fatal("could not found endpoints")
 	}
@@ -157,6 +169,7 @@ func TestResolveLag(t *testing.T) {
 	fc := &fakeConn{
 		cmp: make(chan struct{}),
 	}
+
 	rs, err := bl.Build(parseTarget("kubernetes://kube-dns.kube-system:53"), fc, resolver.BuildOptions{})
 	if err != nil {
 		t.Fatal(err)
@@ -164,9 +177,11 @@ func TestResolveLag(t *testing.T) {
 	defer rs.Close()
 
 	<-fc.cmp
+
 	if len(fc.found) == 0 {
 		t.Fatal("could not found endpoints")
 	}
+
 	time.Sleep(2 * time.Second)
 
 	kresolver := rs.(*kResolver)
@@ -216,10 +231,12 @@ func TestParseResolverTarget(t *testing.T) {
 			t.Errorf("case %d: want error but got nil", i)
 			continue
 		}
+
 		if err != nil && !test.err {
 			t.Errorf("case %d: got '%v' error but don't want an error", i, err)
 			continue
 		}
+
 		if got != test.want {
 			t.Errorf("case %d parseResolverTarget(%q) = %+v, want %+v", i, &test.target.URL, got, test.want)
 		}
@@ -255,10 +272,12 @@ func TestParseTargets(t *testing.T) {
 			t.Errorf("case %d: want error but got nil", i)
 			continue
 		}
+
 		if err != nil && !test.err {
 			t.Errorf("case %d:got '%v' error but don't want an error", i, err)
 			continue
 		}
+
 		if got != test.want {
 			t.Errorf("case %d: parseTarget(%q) = %+v, want %+v", i, test.target, got, test.want)
 		}

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -42,15 +43,19 @@ func (kc *k8sClient) GetRequest(url string) (*http.Request, error) {
 	if !strings.HasPrefix(url, kc.host) {
 		url = fmt.Sprintf("%s/%s", kc.host, url)
 	}
+
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
+
 	kc.tokenLck.RLock()
 	defer kc.tokenLck.RUnlock()
+
 	if len(kc.token) > 0 {
 		req.Header.Set("Authorization", "Bearer "+kc.token)
 	}
+
 	return req, nil
 }
 
@@ -65,6 +70,7 @@ func (kc *k8sClient) Host() string {
 func (kc *k8sClient) setToken(token string) {
 	kc.tokenLck.Lock()
 	defer kc.tokenLck.Unlock()
+
 	kc.token = token
 }
 
@@ -74,14 +80,17 @@ func NewInClusterK8sClient() (K8sClient, error) {
 	if len(host) == 0 || len(port) == 0 {
 		return nil, fmt.Errorf("unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined")
 	}
+
 	token, err := os.ReadFile(serviceAccountToken)
 	if err != nil {
 		return nil, err
 	}
+
 	ca, err := os.ReadFile(serviceAccountCACert)
 	if err != nil {
 		return nil, err
 	}
+
 	certPool := x509.NewCertPool()
 	certPool.AppendCertsFromPEM(ca)
 	transport := &http.Transport{TLSClientConfig: &tls.Config{
@@ -113,14 +122,16 @@ func NewInClusterK8sClient() (K8sClient, error) {
 				// original configmap file is removed
 				if event.Op.Has(fsnotify.Remove) || event.Op.Has(fsnotify.Chmod) {
 					// remove watcher since the file is removed
-					watcher.Remove(event.Name)
+					_ = watcher.Remove(event.Name)
 					// add a new watcher pointing to the new symlink/file
-					watcher.Add(serviceAccountToken)
+					_ = watcher.Add(serviceAccountToken)
+
 					token, err := os.ReadFile(serviceAccountToken)
 					if err == nil {
 						client.setToken(string(token))
 					}
 				}
+
 				if event.Has(fsnotify.Write) {
 					token, err := os.ReadFile(serviceAccountToken)
 					if err == nil {
@@ -158,20 +169,27 @@ func getEndpointSliceList(client K8sClient, namespace, targetName string) (Endpo
 	if err != nil {
 		return EndpointSliceList{}, err
 	}
+
 	req, err := client.GetRequest(u.String())
 	if err != nil {
 		return EndpointSliceList{}, err
 	}
+
 	resp, err := client.Do(req)
 	if err != nil {
 		return EndpointSliceList{}, err
 	}
-	defer resp.Body.Close()
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(resp.Body)
+
 	if resp.StatusCode != http.StatusOK {
 		return EndpointSliceList{}, fmt.Errorf("invalid response code %d for service %s in namespace %s", resp.StatusCode, targetName, namespace)
 	}
+
 	result := EndpointSliceList{}
 	err = json.NewDecoder(resp.Body).Decode(&result)
+
 	return result, err
 }
 
@@ -181,19 +199,27 @@ func watchEndpointSlice(ctx context.Context, client K8sClient, namespace, target
 	if err != nil {
 		return nil, err
 	}
+
 	req, err := client.GetRequest(u.String())
 	if err != nil {
 		return nil, err
 	}
+
 	req = req.WithContext(ctx)
+
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
+
 	if resp.StatusCode != http.StatusOK {
-		defer resp.Body.Close()
+		defer func(Body io.ReadCloser) {
+			_ = Body.Close()
+		}(resp.Body)
+
 		return nil, fmt.Errorf("invalid response code %d for service %s in namespace %s", resp.StatusCode, targetName, namespace)
 	}
+
 	return newStreamWatcher(resp.Body), nil
 }
 
@@ -202,5 +228,6 @@ func getCurrentNamespaceOrDefault() string {
 	if err != nil {
 		return defaultNamespace
 	}
+
 	return string(ns)
 }

--- a/stream.go
+++ b/stream.go
@@ -40,6 +40,7 @@ func newStreamWatcher(r io.ReadCloser) watchInterface {
 		result:  make(chan Event),
 	}
 	go sw.receive()
+
 	return sw
 }
 
@@ -52,9 +53,10 @@ func (sw *streamWatcher) ResultChan() <-chan Event {
 func (sw *streamWatcher) Stop() {
 	sw.Lock()
 	defer sw.Unlock()
+
 	if !sw.stopped {
 		sw.stopped = true
-		sw.r.Close()
+		_ = sw.r.Close()
 	}
 }
 
@@ -62,6 +64,7 @@ func (sw *streamWatcher) Stop() {
 func (sw *streamWatcher) stopping() bool {
 	sw.Lock()
 	defer sw.Unlock()
+
 	return sw.stopped
 }
 
@@ -69,6 +72,7 @@ func (sw *streamWatcher) stopping() bool {
 func (sw *streamWatcher) receive() {
 	defer close(sw.result)
 	defer sw.Stop()
+
 	for {
 		obj, err := sw.Decode()
 		if err != nil {
@@ -76,6 +80,7 @@ func (sw *streamWatcher) receive() {
 			if sw.stopping() {
 				return
 			}
+
 			switch err {
 			case io.EOF:
 				// watch closed normally
@@ -86,8 +91,10 @@ func (sw *streamWatcher) receive() {
 			default:
 				grpclog.Infof("kuberesolver: Unable to decode an event from the watch stream: %v", err)
 			}
+
 			return
 		}
+
 		sw.result <- obj
 	}
 }
@@ -99,6 +106,7 @@ func (sw *streamWatcher) Decode() (Event, error) {
 	if err := sw.decoder.Decode(&got); err != nil {
 		return Event{}, err
 	}
+
 	switch got.Type {
 	case Added, Modified, Deleted, Error:
 		return got, nil

--- a/util.go
+++ b/util.go
@@ -13,12 +13,16 @@ func until(f func(), initialPeriod, maxPeriod time.Duration, stopCh <-chan struc
 		return
 	default:
 	}
+
 	period := initialPeriod
+
 	for {
 		func() {
 			defer handleCrash()
+
 			f()
 		}()
+
 		select {
 		case <-stopCh:
 			return


### PR DESCRIPTION
This PR addresses issue #69 

**Fix tests & add CI**
Make the test suite runnable without a live Kubernetes cluster by adding a mock HTTP server fallback. Tests now check for a kubectl proxy at 127.0.0.1:8001 and automatically use an in-process mock when it's unavailable.

**Also adds:**
- golangci-lint configuration (.golangci.yml)
- GitHub Actions CI workflow (.github/workflows/ci.yml) that runs lint and tests on every PR
- Minor code formatting fixes flagged by the linter